### PR TITLE
Fix references to active checks in passive check templates.

### DIFF
--- a/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5.xml
+++ b/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5.xml
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template UBNT UniFi Controller v5 - active checks</template>
-            <name>Template UBNT UniFi Controller v5 - active checks</name>
+            <template>Template UBNT UniFi Controller v5 - passive checks</template>
+            <name>Template UBNT UniFi Controller v5 - passive checks</name>
             <description>Template for UBNT UniFi Controller by zbx.sadman@gmail.com&#13;
 &#13;
 Tested with controller v5.x, Zabbix v 2.4.&#13;
@@ -734,7 +734,7 @@ aptitude bring a-lot-of-beer</description>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template UBNT UniFi Controller v5 - active checks:unifi.proxy[get,health,{#SITENAME},&quot;[subsystem={#SUBSYSTEM}].status&quot;,,NOT_FOUND].str(&quot;warning&quot;)}=1</expression>
+                            <expression>{Template UBNT UniFi Controller v5 - passive checks:unifi.proxy[get,health,{#SITENAME},&quot;[subsystem={#SUBSYSTEM}].status&quot;,,NOT_FOUND].str(&quot;warning&quot;)}=1</expression>
                             <name>Subsystem &quot;{#SUBSYSTEM}&quot; in warning state</name>
                             <url/>
                             <status>0</status>
@@ -5997,7 +5997,7 @@ aptitude bring a-lot-of-beer</description>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template UBNT UniFi Controller v5 - active checks:unifi.proxy[sum,uap,{#NAME},isolated,,0].min(1m)}&gt;0</expression>
+                            <expression>{Template UBNT UniFi Controller v5 - passive checks:unifi.proxy[sum,uap,{#NAME},isolated,,0].min(1m)}&gt;0</expression>
                             <name>[{#DESC}] Isolated UAPs detected</name>
                             <url/>
                             <status>0</status>
@@ -6006,8 +6006,8 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UniFi Controller v5 - active checks:unifi.proxy[calc,uap,{#NAME},unadopted].last()}</expression>
-                            <name>[{#DESC}] Unactive UAPs detected  ({ITEM.LASTVALUE})</name>
+                            <expression>{Template UBNT UniFi Controller v5 - passive checks:unifi.proxy[calc,uap,{#NAME},unadopted].last()}</expression>
+                            <name>[{#DESC}] Unpassive UAPs detected  ({ITEM.LASTVALUE})</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
@@ -6042,7 +6042,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},guest-num_sta,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6054,7 +6054,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[min,uap,{#NAME},num_sta,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6066,7 +6066,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[max,uap,{#NAME},num_sta,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6078,7 +6078,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},user-num_sta,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6110,7 +6110,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},state,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6122,7 +6122,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},isolated,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6134,7 +6134,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},adopted,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6146,7 +6146,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},locating,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6178,7 +6178,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},&quot;vap_table.rx_errors&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6190,7 +6190,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},&quot;vap_table.tx_errors&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6202,7 +6202,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},rx_bytes,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6214,7 +6214,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#NAME},tx_bytes,,0]</key>
                                     </item>
                                 </graph_item>
@@ -6818,7 +6818,7 @@ aptitude bring a-lot-of-beer</description>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template UBNT UniFi Controller v5 - active checks:unifi.proxy[get,wlan,{#SITENAME},enabled,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT UniFi Controller v5 - passive checks:unifi.proxy[get,wlan,{#SITENAME},enabled,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] WLAN &quot;{#NAME}&quot; is disabled</name>
                             <url/>
                             <status>0</status>
@@ -6827,7 +6827,7 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UniFi Controller v5 - active checks:unifi.proxy[get,wlan,{#SITENAME},security,{#ID}].change()}=1</expression>
+                            <expression>{Template UBNT UniFi Controller v5 - passive checks:unifi.proxy[get,wlan,{#SITENAME},security,{#ID}].change()}=1</expression>
                             <name>[{#SITEDESC}] WLAN &quot;{#NAME}&quot; security mode for is changed</name>
                             <url/>
                             <status>0</status>
@@ -6836,7 +6836,7 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UniFi Controller v5 - active checks:unifi.proxy[get,wlan,{#SITENAME},vlan,{#ID}].change()}=1</expression>
+                            <expression>{Template UBNT UniFi Controller v5 - passive checks:unifi.proxy[get,wlan,{#SITENAME},vlan,{#ID}].change()}=1</expression>
                             <name>[{#SITEDESC}] WLAN &quot;{#NAME}&quot; VLAN is changed</name>
                             <url/>
                             <status>0</status>
@@ -6845,7 +6845,7 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UniFi Controller v5 - active checks:unifi.proxy[get,wlan,{#SITENAME},wpa_mode,{#ID}].change()}=1</expression>
+                            <expression>{Template UBNT UniFi Controller v5 - passive checks:unifi.proxy[get,wlan,{#SITENAME},wpa_mode,{#ID}].change()}=1</expression>
                             <name>[{#SITEDESC}] WLAN &quot;{#NAME}&quot; WPA mode is changed</name>
                             <url/>
                             <status>0</status>
@@ -6883,7 +6883,7 @@ aptitude bring a-lot-of-beer</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>[{#DESC}] Connected clients to UAPs</name>
-                                <host>Template UBNT UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>

--- a/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_UAP.xml
+++ b/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_UAP.xml
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template UBNT UAP - UniFi Controller v5 - active checks</template>
-            <name>Template UBNT UAP - UniFi Controller v5 - active checks</name>
+            <template>Template UBNT UAP - UniFi Controller v5 - passive checks</template>
+            <name>Template UBNT UAP - UniFi Controller v5 - passive checks</name>
             <description>Template for UBNT UniFI Access Point by zbx.sadman@gmail.com&#13;
 &#13;
 Tested with controller v5.x, Zabbix v 2.4.&#13;
@@ -2855,7 +2855,7 @@ Key may not exists if no upgrade need</description>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template UBNT UAP - UniFi Controller v5 - active checks:unifi.proxy[get,uap,{#SITENAME},upgradable,{#ID},0].last()}=1</expression>
+                            <expression>{Template UBNT UAP - UniFi Controller v5 - passive checks:unifi.proxy[get,uap,{#SITENAME},upgradable,{#ID},0].last()}=1</expression>
                             <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; firmware is not latest</name>
                             <url/>
                             <status>0</status>
@@ -2864,7 +2864,7 @@ Key may not exists if no upgrade need</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UAP - UniFi Controller v5 - active checks:unifi.proxy[get,uap,{#SITENAME},version,{#ID}].change()}=1</expression>
+                            <expression>{Template UBNT UAP - UniFi Controller v5 - passive checks:unifi.proxy[get,uap,{#SITENAME},version,{#ID}].change()}=1</expression>
                             <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; firmware version is changed</name>
                             <url/>
                             <status>0</status>
@@ -2873,7 +2873,7 @@ Key may not exists if no upgrade need</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UAP - UniFi Controller v5 - active checks:unifi.proxy[get,uap,{#SITENAME},state,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT UAP - UniFi Controller v5 - passive checks:unifi.proxy[get,uap,{#SITENAME},state,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; is disconnected &gt; 1 min</name>
                             <url/>
                             <status>0</status>
@@ -2882,7 +2882,7 @@ Key may not exists if no upgrade need</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UAP - UniFi Controller v5 - active checks:unifi.proxy[get,uap,{#SITENAME},isolated,{#ID}].min(1m)}=1</expression>
+                            <expression>{Template UBNT UAP - UniFi Controller v5 - passive checks:unifi.proxy[get,uap,{#SITENAME},isolated,{#ID}].min(1m)}=1</expression>
                             <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; is isolated &gt; 1 min</name>
                             <url/>
                             <status>0</status>
@@ -2891,7 +2891,7 @@ Key may not exists if no upgrade need</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UAP - UniFi Controller v5 - active checks:unifi.proxy[get,uap,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT UAP - UniFi Controller v5 - passive checks:unifi.proxy[get,uap,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; is not adopted &gt; 1m</name>
                             <url/>
                             <status>0</status>
@@ -2900,7 +2900,7 @@ Key may not exists if no upgrade need</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UAP - UniFi Controller v5 - active checks:icmpping[{#IP}].max(#3)}=0</expression>
+                            <expression>{Template UBNT UAP - UniFi Controller v5 - passive checks:icmpping[{#IP}].max(#3)}=0</expression>
                             <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; is unavailable by ICMP</name>
                             <url/>
                             <status>0</status>
@@ -2909,7 +2909,7 @@ Key may not exists if no upgrade need</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT UAP - UniFi Controller v5 - active checks:unifi.proxy[get,uap,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT UAP - UniFi Controller v5 - passive checks:unifi.proxy[get,uap,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] USW &quot;{#NAME}&quot; is not adopted &gt; 1m</name>
                             <url/>
                             <status>0</status>
@@ -2945,7 +2945,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[min,user,{#SITENAME},&quot;[ap_mac={#MAC}]._uptime_by_uap&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -2957,7 +2957,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[max,user,{#SITENAME},&quot;[ap_mac={#MAC}]._uptime_by_uap&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -2989,7 +2989,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[max,user,{#SITENAME},&quot;[ap_mac={#MAC}].rx_rate&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3001,7 +3001,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[median,user,{#SITENAME},&quot;[ap_mac={#MAC}].rx_rate&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3013,7 +3013,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[median,user,{#SITENAME},&quot;[ap_mac={#MAC}].tx_rate&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3025,7 +3025,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[max,user,{#SITENAME},&quot;[ap_mac={#MAC}].tx_rate&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3057,7 +3057,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[median ,user,{#SITENAME},&quot;[ap_mac={#MAC}].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3069,7 +3069,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[median,user,{#SITENAME},&quot;[ap_mac={#MAC}].signal&quot;,,-100]</key>
                                     </item>
                                 </graph_item>
@@ -3081,7 +3081,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[max,user,{#SITENAME},&quot;[ap_mac={#MAC}].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3093,7 +3093,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[median,user,{#SITENAME},&quot;[ap_mac={#MAC}].noise&quot;,,-100]</key>
                                     </item>
                                 </graph_item>
@@ -3125,7 +3125,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&gt;25&amp;rssi&lt;=40].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3137,7 +3137,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&gt;40].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3149,7 +3149,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&gt;15&amp;rssi&lt;=25].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3161,7 +3161,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&gt;10&amp;rssi&lt;=15].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3173,7 +3173,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&lt;=10].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3205,7 +3205,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,uap,{#SITENAME},guest-num_sta,{#ID},0]</key>
                                     </item>
                                 </graph_item>
@@ -3217,7 +3217,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,uap,{#SITENAME},user-num_sta,{#ID},0]</key>
                                     </item>
                                 </graph_item>
@@ -3249,7 +3249,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&lt;20].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3261,7 +3261,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&lt;30].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3273,7 +3273,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[ap_mac={#MAC}].[rssi&lt;10].rssi&quot;,,0]</key>
                                     </item>
                                 </graph_item>
@@ -3305,7 +3305,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>icmppingloss[{#IP}]</key>
                                     </item>
                                 </graph_item>
@@ -3317,7 +3317,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>icmppingsec[{#IP}]</key>
                                     </item>
                                 </graph_item>
@@ -3349,7 +3349,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,uap,{#SITENAME},rx_bytes,{#ID},0]</key>
                                     </item>
                                 </graph_item>
@@ -3361,7 +3361,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,uap,{#SITENAME},tx_bytes,{#ID},0]</key>
                                     </item>
                                 </graph_item>
@@ -3373,7 +3373,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#SITENAME},&quot;stat.rx_errors&quot;,{#ID},0]</key>
                                     </item>
                                 </graph_item>
@@ -3385,7 +3385,7 @@ Key may not exists if no upgrade need</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[sum,uap,{#SITENAME},&quot;stat.tx_errors&quot;,{#ID},0]</key>
                                     </item>
                                 </graph_item>
@@ -4442,7 +4442,7 @@ Key may not exists if no upgrade need</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <key>unifi.proxy[median,user,{#SITENAME},&quot;[ap_mac={#MAC}].ccq&quot;,,0]</key>
-                                <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>
@@ -4471,7 +4471,7 @@ Key may not exists if no upgrade need</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <key>unifi.proxy[amean,user,{#SITENAME},&quot;[ap_mac={#MAC}].roam_count&quot;,,0]</key>
-                                <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>
@@ -4500,7 +4500,7 @@ Key may not exists if no upgrade need</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; client RX/TX rate statistic</name>
-                                <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>
@@ -4529,7 +4529,7 @@ Key may not exists if no upgrade need</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; client signal/noise level statistic</name>
-                                <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>
@@ -4558,7 +4558,7 @@ Key may not exists if no upgrade need</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; client signal quality statistic</name>
-                                <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>
@@ -4587,7 +4587,7 @@ Key may not exists if no upgrade need</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>[{#SITEDESC}] UAP &quot;{#NAME}&quot; expected loss of clients with MinRSSI</name>
-                                <host>Template UBNT UAP - UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT UAP - UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>

--- a/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_UGW.xml
+++ b/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_UGW.xml
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template UBNT UGW - UniFi Controller v5 - active checks</template>
-            <name>Template UBNT UGW - UniFi Controller v5 - active checks</name>
+            <template>Template UBNT UGW - UniFi Controller v5 - passive checks</template>
+            <name>Template UBNT UGW - UniFi Controller v5 - passive checks</name>
             <description>Template for UBNT UniFI Gateway by zbx.sadman@gmail.com&#13;
 &#13;
 Tested with controller v5.x, Zabbix v 2.4.&#13;

--- a/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_USW.xml
+++ b/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_USW.xml
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template UBNT USW - UniFi Controller v5 - active checks</template>
-            <name>Template UBNT USW - UniFi Controller v5 - active checks</name>
+            <template>Template UBNT USW - UniFi Controller v5 - passive checks</template>
+            <name>Template UBNT USW - UniFi Controller v5 - passive checks</name>
             <description>Template for UBNT UniFI Switch by zbx.sadman@gmail.com&#13;
 &#13;
 Tested with controller v5.x, Zabbix v 2.4.&#13;
@@ -801,7 +801,7 @@ aptitude bring a-lot-of-beer</description>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template UBNT USW - UniFi Controller v5 - active checks:unifi.proxy[get,usw,{#SITENAME},version,{#ID}].change()}=1</expression>
+                            <expression>{Template UBNT USW - UniFi Controller v5 - passive checks:unifi.proxy[get,usw,{#SITENAME},version,{#ID}].change()}=1</expression>
                             <name>[{#SITEDESC}] USW &quot;{#NAME}&quot; firmware version is changed</name>
                             <url/>
                             <status>0</status>
@@ -810,7 +810,7 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT USW - UniFi Controller v5 - active checks:unifi.proxy[get,usw,{#SITENAME},state,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT USW - UniFi Controller v5 - passive checks:unifi.proxy[get,usw,{#SITENAME},state,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] USW &quot;{#NAME}&quot; is not active &gt; 1m</name>
                             <url/>
                             <status>0</status>
@@ -819,7 +819,7 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT USW - UniFi Controller v5 - active checks:unifi.proxy[get,usw,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT USW - UniFi Controller v5 - passive checks:unifi.proxy[get,usw,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] USW &quot;{#NAME}&quot; is not adopted &gt; 1m</name>
                             <url/>
                             <status>0</status>
@@ -855,7 +855,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT USW - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT USW - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,usw,{#SITENAME},uplink.tx_bytes,{#ID}]</key>
                                     </item>
                                 </graph_item>
@@ -867,7 +867,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT USW - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT USW - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,usw,{#SITENAME},rx_bytes,{#ID}]</key>
                                     </item>
                                 </graph_item>
@@ -879,7 +879,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT USW - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT USW - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,usw,{#SITENAME},uplink.rx_bytes,{#ID}]</key>
                                     </item>
                                 </graph_item>
@@ -891,7 +891,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT USW - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT USW - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[get,usw,{#SITENAME},tx_bytes,{#ID}]</key>
                                     </item>
                                 </graph_item>

--- a/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_User.xml
+++ b/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_User.xml
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template UBNT User - UniFi Controller v5 - active checks</template>
-            <name>Template UBNT User - UniFi Controller v5 - active checks</name>
+            <template>Template UBNT User - UniFi Controller v5 - passive checks</template>
+            <name>Template UBNT User - UniFi Controller v5 - passive checks</name>
             <description>Template for UBNT UniFI User by zbx.sadman@gmail.com&#13;
 &#13;
 Tested with controller v5.x, Zabbix v 2.4.&#13;
@@ -443,7 +443,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>7</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT User - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT User - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[count,user,default,&quot;[oui={#OUI}].oui&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -455,7 +455,7 @@ aptitude bring a-lot-of-beer</description>
                                     <calc_fnc>7</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template UBNT User - UniFi Controller v5 - active checks</host>
+                                        <host>Template UBNT User - UniFi Controller v5 - passive checks</host>
                                         <key>unifi.proxy[pcount,user,{#SITENAME},&quot;[oui={#OUI}].oui&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -614,7 +614,7 @@ aptitude bring a-lot-of-beer</description>
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>[{#SITEDESC}] '{#OUI}' device statistic</name>
-                                <host>Template UBNT User - UniFi Controller v5 - active checks</host>
+                                <host>Template UBNT User - UniFi Controller v5 - passive checks</host>
                             </resource>
                             <max_columns>2</max_columns>
                             <application/>

--- a/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_VoIP.xml
+++ b/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_VoIP.xml
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template UBNT VoIP - UniFi Controller v5 - active checks</template>
-            <name>Template UBNT VoIP - UniFi Controller v5 - active checks</name>
+            <template>Template UBNT VoIP - UniFi Controller v5 - passive checks</template>
+            <name>Template UBNT VoIP - UniFi Controller v5 - passive checks</name>
             <description>Template for UBNT UniFI VoIP by zbx.sadman@gmail.com&#13;
 &#13;
 Tested with controller v5.x, Zabbix v 2.4.&#13;
@@ -374,7 +374,7 @@ aptitude bring a-lot-of-beer</description>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template UBNT VoIP - UniFi Controller v5 - active checks:unifi.proxy[get,uph,{#SITENAME},version,{#ID}].change()}=1</expression>
+                            <expression>{Template UBNT VoIP - UniFi Controller v5 - passive checks:unifi.proxy[get,uph,{#SITENAME},version,{#ID}].change()}=1</expression>
                             <name>[{#SITEDESC}] UPH &quot;{#NAME}&quot;  firmware version is changed</name>
                             <url/>
                             <status>0</status>
@@ -383,7 +383,7 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT VoIP - UniFi Controller v5 - active checks:unifi.proxy[get,uph,{#SITENAME},state,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT VoIP - UniFi Controller v5 - passive checks:unifi.proxy[get,uph,{#SITENAME},state,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] UPH &quot;{#NAME}&quot; is not active &gt; 1m</name>
                             <url/>
                             <status>0</status>
@@ -392,7 +392,7 @@ aptitude bring a-lot-of-beer</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template UBNT VoIP - UniFi Controller v5 - active checks:unifi.proxy[get,uph,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
+                            <expression>{Template UBNT VoIP - UniFi Controller v5 - passive checks:unifi.proxy[get,uph,{#SITENAME},adopted,{#ID}].max(1m)}=0</expression>
                             <name>[{#SITEDESC}] UPH &quot;{#NAME}&quot; is not adopted &gt; 1m</name>
                             <url/>
                             <status>0</status>

--- a/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_Voucher.xml
+++ b/Zabbix_Templates/UniFi Proxy 1.3.0/UBNT_UniFi_Controller_v_5_Passive_Checks/zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5_Voucher.xml
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template UBNT Voucher - UniFi Controller v5 - active checks</template>
-            <name>Template UBNT Voucher - UniFi Controller v5 - active checks</name>
+            <template>Template UBNT Voucher - UniFi Controller v5 - passive checks</template>
+            <name>Template UBNT Voucher - UniFi Controller v5 - passive checks</name>
             <description>Template for UBNT Voucher by zbx.sadman@gmail.com&#13;
 &#13;
 Tested with controller v5.x, Zabbix v 2.4.&#13;

--- a/usr/lib/systemd/system/unifi-proxy.service
+++ b/usr/lib/systemd/system/unifi-proxy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=UniFi Proxy TCP server
+After=network.target
+
+[Service]
+ExecStart=/usr/local/sbin/unifi_proxy.pl -C /etc/unifi_proxy/unifi_proxy.conf
+ExecReload=/bin/pkill -HUP unifi_proxy.pl
+Type=simple
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Descriptions of passive versions of templates have 'active' in their descriptions.

For example in zbx_v2_4_passive_Template_UBNT_UniFi_Controller_v_5.xml
``
<template>Template UBNT UniFi Controller v5 - active checks</template>
            <name>Template UBNT UniFi Controller v5 - active checks</name>
``